### PR TITLE
BACKUP_LIMIT not working for encrypted backups

### DIFF
--- a/lbu.in
+++ b/lbu.in
@@ -482,7 +482,7 @@ cmd_commit() {
 
 	# delete old backups if needed
 	# poor mans 'head -n -N' done with awk.
-	ls "$mnt"/$(hostname).[0-9][0-9][0-9][0-9]*[0-9].tar.gz 2>/dev/null \
+	ls "$mnt"/$(hostname).[0-9][0-9][0-9][0-9]*[0-9].tar.gz* 2>/dev/null \
 		| awk '{ a[++i] = $0; } END {
 			print a[0];
 			while (i-- > '"${BACKUP_LIMIT:-0}"') {

--- a/lbu.in
+++ b/lbu.in
@@ -303,7 +303,7 @@ cmd_package() {
 		run-parts "$LBU_PREPACKAGE" >&2 || return 1
 	fi
 
-	[ -n "$ENCRYPTION" ] && suff="$suff.$ENCRYPTION"
+	[ -n "$ENCRYPTION" ] && [ "x$pkg" != "x-" ] && suff="$suff.$ENCRYPTION"
 
 	# find filename
 	if [ -d "$pkg" ] ; then
@@ -332,7 +332,7 @@ cmd_package() {
 		rc=$?
 	fi
 	if [ $rc -eq 0 ]; then
-		if [ -z "$ENCRYPTION" ]; then
+		if [ -z "$ENCRYPTION" ] || [ "x$pkg" = "x-" ]; then
 			_gen_filelist | $tar_create -z >"$tmppkg"
 			rc=$?
 		else


### PR DESCRIPTION
When you encrypt the backups the BACKUP_LIMIT stop working because the backed up files end with the encryption cipher. Causing the backups to pile up after each commit.