### PR TITLE
setup-disk fails because of 'lbu package - | tar' & encryption config

### DIFF
--- a/lbu.in
+++ b/lbu.in
@@ -303,7 +303,7 @@ cmd_package() {
 		run-parts "$LBU_PREPACKAGE" >&2 || return 1
 	fi
 
-	[ -n "$ENCRYPTION" ] && suff="$suff.$ENCRYPTION"
+	[ -n "$ENCRYPTION" ] && [ "x$pkg" != "x-" ] && suff="$suff.$ENCRYPTION"
 
 	# find filename
 	if [ -d "$pkg" ] ; then
@@ -332,7 +332,7 @@ cmd_package() {
 		rc=$?
 	fi
 	if [ $rc -eq 0 ]; then
-		if [ -z "$ENCRYPTION" ]; then
+		if [ -z "$ENCRYPTION" ] || [ "x$pkg" = "x-" ]; then
 			_gen_filelist | $tar_create -z >"$tmppkg"
 			rc=$?
 		else

--- a/lbu.in
+++ b/lbu.in
@@ -635,10 +635,7 @@ cmd_status() {
 	unpack_apkovl "$tmp/a"
 
 	# generate new apkovl and extract to tmpdir/b
-	local save_encryption="$ENCRYPTION"
-	ENCRYPTION=
 	cmd_package - | tar -C "$tmp/b" -zx
-	ENCRYPTION="$save_encryption"
 
 	# show files that exists in a but not in b as deleted
 	local f
@@ -687,7 +684,6 @@ cmd_diff() {
 	init_tmpdir tmp
 	mkdir -p "$tmpdir/a" "$tmp/b"
 	unpack_apkovl "$tmp/a"
-	ENCRYPTION=
 	cmd_package - | tar -C "$tmp/b" -zx
 	if diff --help 2>&1 | grep -q -- --no-dereference; then
 		diff_opts="--no-dereference"


### PR DESCRIPTION
When booting from an Alpine backup encrypted USB stick to create a new sys installation on a different media, the setup-disk fails at line 266: "lbu package - | tar" because "lbu package" is incapable of ignoring the encryption config.