### PR TITLE
setup-disk: add xfs support as boot_fs

### DIFF
--- a/setup-disk.in
+++ b/setup-disk.in
@@ -141,7 +141,7 @@ find_mount_dev() {
 }
 
 supported_boot_fs() {
-	local supported="ext2 ext3 ext4 btrfs"
+	local supported="ext2 ext3 ext4 btrfs xfs"
 	local fs=
 	for fs in $supported; do
 		[ "$fs" = "$1" ] && return 0
@@ -937,7 +937,7 @@ usage() {
 		If BOOTFS, ROOTFS, VARFS are specified, then format a partition with specified
 		filesystem. If not specified, the default filesystem is ext4.
 		Supported filesystems for
-		  boot: ext2, ext3, ext4, btrfs
+		  boot: ext2, ext3, ext4, btrfs, xfs
 		  root: ext2, ext3, ext4, btrfs, xfs
 		   var: ext2, ext3, ext4, btrfs, xfs
 	__EOF__


### PR DESCRIPTION
Works very well with latest XFS metadata since SYSLINUX 6.03.
The [Syslinux Wiki](http://www.syslinux.org/wiki/index.php?title=EXTLINUX) says:

> EXTLINUX supports:
> [3.00+] ext2/3,
> [4.00+] FAT12/16/32, ext2/3/4, Btrfs,
> [4.06+] FAT12/16/32, NTFS, ext2/3/4, Btrfs,
> [5.01+] FAT12/16/32, NTFS, ext2/3/4, Btrfs, XFS,
> [6.03+] FAT12/16/32, NTFS, ext2/3/4, Btrfs, XFS, UFS/FFS,