### PR TITLE
setup-keymap: be agnostic with regards to keymap compression type

### DIFF
--- a/setup-keymap.in
+++ b/setup-keymap.in
@@ -7,15 +7,24 @@ MAPDIR="$ROOT/usr/share/bkeymaps"
 
 if [ -f "$ROOT/etc/conf.d/keymaps" ]; then
 	. "$ROOT/etc/conf.d/keymaps"
-	variant=$(basename $KEYMAP .bmap.gz)
+	variant=$(basename "KEYMAP")
+	variant="${variant%%.*}"
 fi
 
 
-show_keymaps() {
-	local opwd="$PWD"
-	cd "$ROOT/usr/share/bkeymaps"
+show_layouts() {
+	local owpd; owpd="$PWD"
+	cd "$MAPDIR"
 	ls --color=never
-	cd "$opwd"
+	cd "$owpd"
+}
+
+show_variants() {
+	local i; for i in "$MAPDIR/$1"/* ; do
+		i="$(basename "$i")"
+		printf "%s " "${i%%.*}"
+	done
+	echo
 }
 
 select_layout() {
@@ -24,7 +33,7 @@ select_layout() {
 			layout=none
 		fi
 		echo "Available keyboard layouts:"
-		show_keymaps
+		show_layouts
 		echon "Select keyboard layout [$layout]: "
 		default_read layout "$layout"
 		if [ "$layout" = "abort" ] || [ "$layout" = "none" ] ; then
@@ -36,15 +45,15 @@ select_layout() {
 }
 
 setup_mapfile() {
-	local name=$(basename $1)
+	local name=$(basename "$1")
 	local conf="$ROOT/etc/conf.d/keymaps"
 	mkdir -p "$ROOT/etc/keymap"
 	mkdir -p "$ROOT/etc/conf.d/"
-	if gzip -9 -c "$1" > "$ROOT/etc/keymap/$name.gz" ; then
+	if cp "$1" "$ROOT/etc/keymap/$name" ; then
 		[ -f "$conf" ] && sed -i '/^KEYMAP=/d' "$conf"
-		echo "KEYMAP=/etc/keymap/$name.gz" >> "$conf"
+		echo "KEYMAP=/etc/keymap/$name" >> "$conf"
 		# we actually load the keymap now
-		zcat /etc/keymap/$name.gz | loadkmap
+		rc-service keymaps restart
 		rc-update -q add keymaps boot
 		goodbye 0
 	fi
@@ -53,10 +62,7 @@ setup_mapfile() {
 select_variant() {
 	while true; do
 		echon "Available variants: "
-		for i in $(ls $MAPDIR/$layout) ; do
-			echon "$(basename $i .bmap) "
-		done
-		echo ""
+		show_variants "$layout"
 		if [ ! -f "$MAPDIR/$layout/$variant.bmap" ] ; then
 			variant=""
 		fi
@@ -65,23 +71,19 @@ select_variant() {
 		if [ "$variant" = "abort" ] || [ "$variant" = "none" ]; then
 			break;
 		fi
-		if [ -f "$MAPDIR/$layout/$variant.bmap" ]; then
-			setup_mapfile "$MAPDIR/$layout/$variant.bmap"
+		if [ -f "$MAPDIR/$layout/$variant.bmap"* ]; then
+			setup_mapfile "$MAPDIR/$layout/$variant.bmap"*
 		fi
-	done	
+	done
 }
 
 goodbye() {
-	if [ $was_installed -ne 0 ]; then
-		apk del --quiet bkeymaps
-	fi
+	apk del --quiet --no-progress .setup-keymap-deps
 	exit $1
 }
 
-apk info --quiet --installed bkeymaps
-was_installed=$?
-
-apk add --quiet bkeymaps
+trap 'goodbye 1' INT
+apk add --quiet --virtual .setup-keymap-deps kbd-bkeymaps
 
 deflayout="$1"
 defvariant="$2"
@@ -98,13 +100,13 @@ while true; do
 	fi
 
 	# if variant is defined, this could match, otherwise we'll have to choose a variant
-	if [ -f "$MAPDIR/$layout/$variant.bmap" ]; then
-		setup_mapfile "$MAPDIR/$layout/$variant.bmap"
+	if [ -f "$MAPDIR/$layout/$variant.bmap"* ]; then
+		setup_mapfile "$MAPDIR/$layout/$variant.bmap"*
 	else
 		# if there is only one variant, just pick it
-		count=$(ls $MAPDIR/$layout | wc -l)
+		count=$(ls "$MAPDIR"/"$layout" | wc -l)
 		if [ $count -eq 1 ]; then
-			setup_mapfile "$MAPDIR/$layout/$(ls $MAPDIR/$layout)"
+			setup_mapfile "$MAPDIR/$layout/"*
 			continue
 		fi
 		select_variant


### PR DESCRIPTION
This commit is meant to be merged in tandem with https://github.com/alpinelinux/aports/pull/1373 (as it includes the rename from `bkeymaps` to `kbd-bkeymaps`).