### PR TITLE
lbu: use ROOT environment var in package command

### DIFF
--- a/lbu.in
+++ b/lbu.in
@@ -285,7 +285,7 @@ usage_package() {
 }
 
 _gen_filelist() {
-	apk audit --backup --quiet --recursive --check-permissions
+	apk audit --root ${ROOT:-/} --backup --quiet --recursive --check-permissions
 }
 
 cmd_package() {


### PR DESCRIPTION
I'd like to prepare the LBU archives on a temporary root.