### PR TITLE
Modify setup-disk to correctly ignore swap when appropriate.

### DIFF
--- a/setup-disk.in
+++ b/setup-disk.in
@@ -659,8 +659,10 @@ setup_partitions() {
 	# create new partitions
 	(
 		for line in "$@"; do
-			echo "$start,$line"
-			start=
+			if case $line in 0M*) false;; *) true;; esac; then
+				echo "$start,$line"
+				start=
+			fi
 		done
 	) | sfdisk --quiet --label $DISKLABEL $diskdev
 


### PR DESCRIPTION
The `setup-disk` script is used as a part of any persistent installation of Alpine Linux, whether directly or as a part of the `setup-alpine` procedure. A bit of experimentation with the script has yielded that there's no way to actually install Alpine without swap, despite the `setup-disk` help documentation indicating it is possible. While generally not an issue, service providers such as Vultr or Digital Ocean appreciate customers not enabling swap on their virtual instances due to the wear it causes on SSDs[1].

If `-s 0` is provided to `setup-disk`, it provides the following to the `sfdisk` utility which is used to set the partitioning table:

```
1M,100M,83,*
,0M,82
,,83
```

Removing the `--quiet` flag in the `setup-disk` call to `sfdisk` yielded the following indicator that the partition is still being created:

```
Device     Boot  Start      End  Sectors  Size Id Type
/dev/vda1  *      2048   206847   204800  100M 83 Linux
/dev/vda2       206848   206848        1  512B 82 Linux swap / Solaris
/dev/vda3       208896 52428799 52219904 24.9G 83 Linux
```

Despite being only one sector / 512B, it'd be ideal for the actual outcome of `setup-disk` to reflect operator intent: No swap created at all. Technically speaking, 512B is not equivalent to 0, and a created partition is not equivalent to "disabled swap".

I wrote up a basic proof-of-concept patch which I use for my own servers[2]. In order to avoid using bashisms, I opted to use a `case` statement to check for the presence of '0M' at the beginning of a line, indicating it is to be a zero-size partition.

Based on conversation with @Xe I opted to submit a bug report too[3].

[1]: https://www.digitalocean.com/community/tutorials/how-to-add-swap-space-on-ubuntu-16-04
[2]: https://github.com/elliotspeck/alpine-conf/commit/3208937bc33d38f1c21596b915311ae2790cd52c
[3]: https://bugs.alpinelinux.org/issues/8798