### PR TITLE
setup-apkrepos: Allow the script to pick a server with 0.00sec download time and replaced the awk script with tee|sort|head|cut magic

### DIFF
--- a/setup-apkrepos.in
+++ b/setup-apkrepos.in
@@ -57,19 +57,7 @@ find_fastest_mirror() {
 		if [ -n "$time" ]; then
 			echo "$time $url"
 		fi
-	done | awk ' {
-		if (!current) {
-			current=$1
-			url=$2
-		} else {
-			if ($1 < current) {
-				current=$1
-				url=$2
-			}
-		}
-		printf("%6.2f %s\n", $1, $2) > "/dev/stderr"
-	}
-	END { print url }'
+	done | tee /dev/stderr | sort -nk1,1 | head -n1 | cut -d' ' -f2
 }
 
 add_fastest_mirror() {


### PR DESCRIPTION
The setup-apkrepos script ignores servers with a download time of 0.00 (very close mirror) due to `if (!current) {` being true since `!0.00` equals true (or `1` in awk) thus resetting the entire result set to a possible slower server:

```
Finding fastest mirror...
0.13 http://dl-cdn.alpinelinux.org/alpine/
0.07 http://nl.alpinelinux.org/alpine/
0.07 http://uk.alpinelinux.org/alpine/
0.22 http://dl-2.alpinelinux.org/alpine/
0.28 http://dl-3.alpinelinux.org/alpine/
0.06 http://dl-4.alpinelinux.org/alpine/
0.05 http://dl-5.alpinelinux.org/alpine/
0.08 http://dl-8.alpinelinux.org/alpine/
0.1 http://mirror.yandex.ru/mirrors/alpine/
0.26 http://mirrors.gigenet.com/alpinelinux/
0.06 http://mirror1.hs-esslingen.de/pub/Mirrors/alpine/
0.08 http://mirror.leaseweb.com/alpine/
0.07 http://repository.fit.cvut.cz/mirrors/alpine/
0 http://alpine.mirror.far.fi/
0.06 http://alpine.mirror.wearetriple.com/
0.22 http://mirror.clarkson.edu/alpine/
0.56 http://linorg.usp.br/AlpineLinux/
0.6 http://ftp.yzu.edu.tw/Linux/alpine/
0.65 http://mirror.aarnet.edu.au/pub/alpine
0.25 http://mirror.csclub.uwaterloo.ca/alpine
0.04 http://ftp.acc.umu.se/mirror/alpinelinux.org
0.05 http://ftp.halifax.rwth-aachen.de/alpine
0.13 http://speglar.siminn.is/alpine
0.06 http://mirrors.dotsrc.org/alpine
0.51 http://ftp.tsukuba.wide.ad.jp/Linux/alpine
0.65 http://mirror.rise.ph/alpine
6.09 http://mirror.neostrada.nl/alpine/
Added mirror ftp.acc.umu.se
Updating repository indexes... done.
```

This patch replaces awk with four commands:

- `tee /dev/stderr` to duplicate the result stdout to the users terminal
- `sort -nk1,1` to numerically sort by the first column, the download time
- `head -n1` picks the first line (the server with the lowest download time, obviously)
- `cut -d' ' -f2` to grab the second column (the url) since we don't want the download time to be in the `repositories` file

Result is as expected now:

```
Finding fastest mirror...
0.13 http://dl-cdn.alpinelinux.org/alpine/
0.07 http://nl.alpinelinux.org/alpine/
0.07 http://uk.alpinelinux.org/alpine/
0.21 http://dl-2.alpinelinux.org/alpine/
0.28 http://dl-3.alpinelinux.org/alpine/
0.06 http://dl-4.alpinelinux.org/alpine/
0.05 http://dl-5.alpinelinux.org/alpine/
0.09 http://dl-8.alpinelinux.org/alpine/
0.07 http://mirror.yandex.ru/mirrors/alpine/
0.28 http://mirrors.gigenet.com/alpinelinux/
0.06 http://mirror1.hs-esslingen.de/pub/Mirrors/alpine/
0.06 http://mirror.leaseweb.com/alpine/
0.07 http://repository.fit.cvut.cz/mirrors/alpine/
0 http://alpine.mirror.far.fi/
0.06 http://alpine.mirror.wearetriple.com/
0.23 http://mirror.clarkson.edu/alpine/
0.58 http://linorg.usp.br/AlpineLinux/
0.6 http://ftp.yzu.edu.tw/Linux/alpine/
0.61 http://mirror.aarnet.edu.au/pub/alpine
0.28 http://mirror.csclub.uwaterloo.ca/alpine
0.04 http://ftp.acc.umu.se/mirror/alpinelinux.org
0.05 http://ftp.halifax.rwth-aachen.de/alpine
0.13 http://speglar.siminn.is/alpine
0.06 http://mirrors.dotsrc.org/alpine
0.51 http://ftp.tsukuba.wide.ad.jp/Linux/alpine
0.62 http://mirror.rise.ph/alpine
0.06 http://mirror.neostrada.nl/alpine/
Added mirror alpine.mirror.far.fi
Updating repository indexes... done.
```