### PR TITLE
alpine-conf: fix boot issue by having grub.cfg use linux-vanilla

### DIFF
--- a/setup-disk.in
+++ b/setup-disk.in
@@ -307,11 +307,7 @@ setup_grub() {
 	fi
 
 	# setup GRUB config
-	local kernel
-	case $KERNEL_FLAVOR in
-		vanilla) kernel=vmlinuz ;;
-		*) kernel=vmlinuz-$KERNEL_FLAVOR ;;
-	esac
+	local kernel=vmlinuz-$KERNEL_FLAVOR
 
 	# all_video is needed to remove the video error on boot
 	cat > "$mnt"/boot/grub/grub.cfg <<- EOF


### PR DESCRIPTION
fixes boot failure since during install /sbin/setup-disk script still sets up boot binary in grub.cfg as /boot/vmlinuz. This isn't consistent with linux-vanilla apk which actually installs binary /boot/vmlinuz-vanilla so first reboot after install fails.

This problem was detected on 3.8 rc1 ppc64le installs. tmh1999 also reports that this also occurs on x86_64 installs. 

I don't have the hardware to check on other platforms so someone with in depth knowledge of vmlinuz* naming on all platforms should review.