### PR TITLE
Fix TZ handling in setup-timezone

### DIFF
--- a/setup-timezone.in
+++ b/setup-timezone.in
@@ -40,21 +40,17 @@ show_tz_list() {
 }
 
 setup_tz() {
-	local zonepath="$1"
-	mkdir -p "${ROOT}"etc/zoneinfo
-	if ! $INSTALL_TZDATA; then
-		local zone="${zonepath#*/zoneinfo/}"
-		local zdir="${zonepath%/*}"/
-		zdir="${zdir#*/zoneinfo/}"
-		if ! $KEEP_TZDATA; then
-			rm -r "${ROOT}"/etc/zoneinfo
+	local zone="$1"
+
+	if ! $KEEP_TZDATA; then
+		cp "$zroot"/"$zone" /etc/localtime
+		rm /etc/profile.d/timezone.sh
+	else
+		if ! $INSTALL_TZDATA; then
+			install -Dm644 "$zroot"/"$zone" /etc/zoneinfo/"$zone"
 		fi
-		mkdir -p "${ROOT}"etc/zoneinfo/$zdir
-		cp "$zonepath" "${ROOT}"etc/zoneinfo/$zdir/
-		zonepath=/etc/zoneinfo/$zone
+		echo "export TZ='$zone'" > /etc/profile.d/timezone.sh
 	fi
-	rm -f "${ROOT}"etc/localtime
-	ln -s "$zonepath" "${ROOT}"etc/localtime
 }
 
 INSTALL_TZDATA=false
@@ -88,7 +84,7 @@ fi
 
 while true; do
 	if [ -n "$ZONE" ]; then
-		setup_tz "$zroot"/"$ZONE"
+		setup_tz "$ZONE"
 		break
 	fi
 
@@ -110,7 +106,7 @@ while true; do
 	done
 
 	if [ -f "$zroot/$timezone" ]; then
-		setup_tz "$zroot/$timezone"
+		setup_tz "$timezone"
 		break
 	fi
 	echo "'$timezone' is not a valid timezone on this system"

--- a/setup-timezone.in
+++ b/setup-timezone.in
@@ -54,7 +54,7 @@ setup_tz() {
 }
 
 INSTALL_TZDATA=false
-KEEP_TZDATA=false
+KEEP_TZDATA=true
 while getopts "hikIKz:" opt; do
 	case $opt in
 		h) usage;;

--- a/setup-timezone.in
+++ b/setup-timezone.in
@@ -55,11 +55,13 @@ setup_tz() {
 
 INSTALL_TZDATA=false
 KEEP_TZDATA=false
-while getopts "hikz:" opt; do
+while getopts "hikIKz:" opt; do
 	case $opt in
 		h) usage;;
 		i) INSTALL_TZDATA=true;;
+		I) INSTALL_TZDATA=false;;
 		k) KEEP_TZDATA=true;;
+		K) KEEP_TZDATA=false;;
 		z) ZONE="$OPTARG";;
 	esac
 done


### PR DESCRIPTION
Patch (series) 2 in fixing setup-alpine's TZ handling.
First patch is against aports.

Musl primarily cares about the TZ environment variable.
So let's use that (by default) instead of localtime shenanigans.
Also allow doing /etc/zoneinfo properly (first commit) and simplify logic.