### PR TITLE
setup-apkrepos: fix accepting options

### DIFF
--- a/setup-apkrepos.in
+++ b/setup-apkrepos.in
@@ -157,7 +157,7 @@ community_prefix="# "
 add_fastest=false
 add_first=false
 add_random=false
-while getopts "1fhr" opt; do
+while getopts "c1fhr" opt; do
 	case $opt in
 		c) community_prefix="";;
 		f) add_fastest=true;;


### PR DESCRIPTION
`-c` option was (mistakenly?) omitted in `getopts` call. Causing following error;

    # setup-apkrepos -1 -c
    Illegal option -c
    Added mirror dl-cdn.alpinelinux.org
    Updating repository indexes... done.

Tested this change locally and it works as expected.