### PR TITLE
Added no_proxy=localhost variable to ensure that no proxy is used when connecting to localhost.

### DIFF
--- a/setup-proxy.in
+++ b/setup-proxy.in
@@ -60,6 +60,7 @@ else
 		export http_proxy=$proxyurl
 		export https_proxy=$proxyurl
 		export ftp_proxy=$proxyurl
+		export no_proxy=localhost
 	__EOF__
 	# busybox wget does not handle http proxies well
 	apk add --quiet --no-progress wget


### PR DESCRIPTION
I noticed that when a proxy is set, it's used even when connecting to localhost. I propose adding localhost to the no_proxy environment variable.