### PR TITLE
Fix typo in setup-user.in

### DIFF
--- a/setup-user.in
+++ b/setup-user.in
@@ -109,7 +109,7 @@ if [ -n "$interactive" ] && [ -z "$keysopt" ]; then
 else
 	case "$keysopt" in
 		https://*|http://*)
-			sshkeys=$(wget -q -O- "$sshkeys" | grep ^ssh-);;
+			sshkeys=$(wget -q -O- "$keysopt" | grep ^ssh-);;
 		none)
 			sshkeys="" ;;
 		*)


### PR DESCRIPTION
If you attempt to pass a url using -k, it will fail with a wget error: $sshkeys is blank at this point.

Changed the variable to $keysopt: Testing the changes shows it works as expected.