### PR TITLE
Skip asking for disk if passing -m none

### DIFF
--- a/setup-disk.in
+++ b/setup-disk.in
@@ -1539,14 +1539,16 @@ if [ $# -gt 0 ]; then
 		diskdevs="$diskdevs /dev/${j//!//}"
 	done
 else
-	ask_disk "Which disk(s) would you like to use? (or '?' for help or 'none')" \
-		diskselect_help $disks
-	if [ "$resp" != none ]; then
-		for i in $resp; do
-			diskdevs="$diskdevs /dev/$i"
-		done
-	else
-		DISK_MODE="none"
+	if [ "$DISK_MODE" != none ]; then
+		ask_disk "Which disk(s) would you like to use? (or '?' for help or 'none')" \
+			diskselect_help $disks
+		if [ "$resp" != none ]; then
+			for i in $resp; do
+				diskdevs="$diskdevs /dev/$i"
+			done
+		else
+			DISK_MODE="none"
+		fi
 	fi
 fi
 


### PR DESCRIPTION
I've added a branch before the script asks for the disk to use so that if you pass -m none, it doesn't still try to ask for a disk.

This may be better served by an earlier check where if you pass -m none specifically it just exits then and there. Currently, there is no way to use an answers file for a diskless setup due to this issue (Now you can include DISKOPTS="-m none" in an answers file)