### PR TITLE
Add unlock argument for setup-user

### DIFF
--- a/setup-user.in
+++ b/setup-user.in
@@ -17,6 +17,8 @@ usage() {
 		 -g  Comma or space separated list of groups to add user to
 		 -k  ssh key or URL to ssh key (eg. https://gitlab.alpinelinux.org/user.keys)
 		     or 'none' for no key
+		 -u  Unlock the user automatically (eg. creating the user non-interactively
+		     with an ssh key for login)
 
 		If USERNAME is not specified user will be prompted.
 	__EOF__
@@ -30,6 +32,7 @@ while getopts "af:g:hk:" opt; do
 		f) fullnameopt="$OPTARG";;
 		g) groups="$OPTARG";;
 		k) keysopt="$OPTARG";;
+		u) forceunlock=1;;
 		'?') usage "1" >&2;;
 	esac
 done
@@ -140,3 +143,6 @@ if [ -n "$admin" ]; then
 	$MOCK addgroup "$username" "wheel" || exit
 fi
 
+if [-n "$forceunlock" ]; then
+	$MOCK passwd -u "$username" 2> /dev/null
+fi

--- a/setup-user.in
+++ b/setup-user.in
@@ -6,7 +6,7 @@ PREFIX=@PREFIX@
 
 usage() {
 	cat <<-__EOF__
-		usage: setup-user [-h] [-f FULLNAME] [-g GROUPS] [-k SSHKEY] [USERNAME]
+		usage: setup-user [-h] [-a] [-u] [-f FULLNAME] [-g GROUPS] [-k SSHKEY] [USERNAME]
 
 		Create user account
 
@@ -25,7 +25,7 @@ usage() {
 	exit $1
 }
 
-while getopts "af:g:hk:" opt; do
+while getopts "af:g:hk:u" opt; do
 	case $opt in
 		a) admin=1;;
 		h) usage 0;;
@@ -143,6 +143,6 @@ if [ -n "$admin" ]; then
 	$MOCK addgroup "$username" "wheel" || exit
 fi
 
-if [-n "$forceunlock" ]; then
+if [ -n "$forceunlock" ]; then
 	$MOCK passwd -u "$username" 2> /dev/null
 fi


### PR DESCRIPTION
Adds a -u argument: useful for if you want to create a user non-interactively that logs in with an ssh key (Passed by -k) without needing to unlock the user manually afterwards.

The reasoning for this is that if you set no password needed, adduser automatically locks the account from logging in.

Empty SSH logins are already prevented, so this means a user can log in using ssh with the already configured key and simply use passwd when logging in with no other changes if -u is passed.

I pipe the stderr to /dev/null as regardless of whether the unlock is needed / does anything, passwd reports that the password was reset or if the user was already unlocked: I presume that, similar to adding groups, the user knows what changes they are requesting. It may be preferred to clear $forceunlock if the credentials are being added interactively: I prefer just performing the action regardless, but it may be desirable to report any odd errors besides the (2?) I assume users are going to see.